### PR TITLE
Fix handling of multiple properties per index/key

### DIFF
--- a/DbContextOnModelCreatingSplitter/Program.cs
+++ b/DbContextOnModelCreatingSplitter/Program.cs
@@ -47,7 +47,7 @@ namespace DbContextOnModelCreatingSplitter
 
             var configurationNamespace = options.Namespace ?? contextNamespace;
 
-            const string statementsInnerBlockPattern = @"(?<=modelBuilder\.Entity<(?<EntityName>.*?)>\((?<EntityParameterName>.*?)\s*=>\s*\{).*?(?=\s*\}\);)";
+            const string statementsInnerBlockPattern = @"(?<=modelBuilder\.Entity<(?<EntityName>.*?)>\((?<EntityParameterName>.*?)\s*=>\s*\{).*?(?=\r?\n\s*\}\);)";
 
             var statementsBlockMatches = Regex.Matches(source, statementsInnerBlockPattern, RegexOptions.Multiline | RegexOptions.Singleline)
                 .ToList();
@@ -93,7 +93,7 @@ namespace DbContextOnModelCreatingSplitter
                 return;
             }
 
-            const string statementsOuterBlockPattern = @"\s*modelBuilder\.Entity<.*?>\(.*?\s*=>\s*\{.*?\}\);";
+            const string statementsOuterBlockPattern = @"\s*modelBuilder\.Entity<.*?>\(.*?\s*=>\s*\{.*?\r?\n\s*\}\);\r?\n";
 
             source = Regex.Replace(source, statementsOuterBlockPattern, string.Empty, RegexOptions.Multiline | RegexOptions.Singleline);
             if (!options.NoBackup)


### PR DESCRIPTION
A statement like the following could throw off the used regular expression, due to the `});` in the configuration block:

```c#
modelBuilder.Entity<UserRole>(entity =>           
{ 
    // ...
    entity.HasKey(e => new { e.UserId, e.RoleId });
    // ...
});
```

Fixes #1